### PR TITLE
尝试修复 TRSS-Yunzai 非icqq协议无法正常获取头像

### DIFF
--- a/lib/mysapi.js
+++ b/lib/mysapi.js
@@ -256,7 +256,7 @@ export default class MysZZZApi extends MysApi {
       case 10041:
       case 5003:
         this.e.reply(
-          `UID:${this.uid}，米游社账号异常，暂时无法查询，请尝试%绑定设备`
+          `UID:${this.uid}，米游社账号异常，暂时无法查询，请尝试 %绑定设备帮助`
         );
         break;
       case 10035:

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -191,13 +191,13 @@ export class ZZZPlugin extends plugin {
       userData?.list?.find(item => item.game_uid == uid) || userData?.list?.[0];
 
     // 获取用户头像
-    let avatar = this.e?.bot?.avatar || '';
-    if (this.e?.user_id) {
-      avatar = `https://q1.qlogo.cn/g?b=qq&s=0&nk=${this.e.user_id}`;
-    } else if (this.e.member?.getAvatarUrl) {
+    let avatar = '';
+    if (this.e.member?.getAvatarUrl) {
       avatar = await this.e.member.getAvatarUrl();
     } else if (this.e.friend?.getAvatarUrl) {
       avatar = await this.e.friend.getAvatarUrl();
+    } else {
+      avatar = this.e?.bot?.avatar
     }
     // 写入数据
     this.e.playerCard = {


### PR DESCRIPTION
# fix #43
@bietiaop

## 已知问题
我将获取头像的代码改为了喵崽和TRSS崽共同可用的代码段，但是我的QQBot即使正确获取了头像url(已使用console.log查看)，但仍然无法渲染上去，显示无效图片，喵崽测试正常
### 以下提供`%更新面板`结果图片
![QQBot `%更新面板`结果图片](https://github.com/user-attachments/assets/1cd4dfd2-8620-4266-9953-9664af76be64)
### 以下提供 后台日志(含头像url输出)图片
![后台日志(含头像url输出)图片](https://github.com/user-attachments/assets/089dfc4a-3ebb-442e-a988-ac31596a5e2b)
### 以下提供 QQBot 获取的头像url(上图框选内容)
https://q.qlogo.cn/qqapp/102068043/1C52ABB3617BFF5F187C0EAF45FF8EC1/0

## 如果是代码的问题恳请大佬修复测试，如果是我机器人的问题算我的
