### PR TITLE
修复危局查询中无邦布信息导致的报错，为其追加空白默认值

### DIFF
--- a/model/deadly.js
+++ b/model/deadly.js
@@ -71,6 +71,10 @@ import { Buffer } from 'node:buffer';
  * @property {DeadlyList[]} list
  */
 
+
+// 1x1像素透明，用于填充无图情况
+const BLANK_IMAGE = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=';
+
 /**
  * @class Deadly.
  */
@@ -169,6 +173,15 @@ export class Buddy {
    * @param {Buddy} data
    */
   constructor(data) {
+    //无邦布信息的时候使用默认空值
+    if (!data) {
+      this.id = 0;
+      this.rarity = '';
+      this.level = 0;
+      //邦布使用透明图
+      this.bangboo_rectangle_url = BLANK_IMAGE;
+      return;
+    }
     this.id = data.id;
     this.rarity = data.rarity;
     this.level = data.level;


### PR DESCRIPTION
Update deadly.js
危局查询中如果用户打危局没有带邦布，api返回的邦布信息会直接为空，data.id取值会报错，添加了默认值在没有邦布信息时使之显示为空白 #139 