### PR TITLE
feat: 新增 %角色名别名 查看角色别名

### DIFF
--- a/src/apps/help.ts
+++ b/src/apps/help.ts
@@ -624,6 +624,13 @@ export class Help extends ZZZPlugin {
               commands: ['删除别名+角色别名'],
             },
             {
+              title: '查看角色别名',
+              desc: '查看某个角色当前可用的全部别名',
+              needCK: false,
+              needSK: false,
+              commands: ['角色名+别名'],
+            },
+            {
               title: '上传角色面板图',
               desc: '上传自定义角色面板图，可以随消息附带图片，可以通过引用消息中的图片上传',
               needCK: false,

--- a/src/apps/manage.ts
+++ b/src/apps/manage.ts
@@ -15,6 +15,7 @@ export class Manage extends ZZZPlugin {
   setRefreshCharInterval: typeof manage.config.setRefreshCharInterval
   addAlias: typeof manage.alias.addAlias
   deleteAlias: typeof manage.alias.deleteAlias
+  listAlias: typeof manage.alias.listAlias
   uploadCharacterImg: typeof manage.panel.uploadCharacterImg
   getCharacterImages: typeof manage.panel.getCharacterImages
   deleteCharacterImg: typeof manage.panel.deleteCharacterImg
@@ -76,6 +77,10 @@ export class Manage extends ZZZPlugin {
           fnc: 'deleteAlias'
         },
         {
+          reg: `${rulePrefix}(\\S+)别名$`,
+          fnc: 'listAlias'
+        },
+        {
           reg: `${rulePrefix}(上传|添加)(\\S+)(角色|面板)图$`,
           fnc: 'uploadCharacterImg'
         },
@@ -132,6 +137,7 @@ export class Manage extends ZZZPlugin {
     this.setRefreshCharInterval = manage.config.setRefreshCharInterval
     this.addAlias = manage.alias.addAlias
     this.deleteAlias = manage.alias.deleteAlias
+    this.listAlias = manage.alias.listAlias
     this.uploadCharacterImg = manage.panel.uploadCharacterImg
     this.getCharacterImages = manage.panel.getCharacterImages
     this.deleteCharacterImg = manage.panel.deleteCharacterImg

--- a/src/apps/manage/alias.ts
+++ b/src/apps/manage/alias.ts
@@ -1,5 +1,6 @@
 import type { EventType } from '#interface'
 import { char } from '../../lib/convert.js'
+import { rulePrefix } from '../../lib/common.js'
 import settings from '../../lib/settings.js'
 
 export async function addAlias(e: EventType) {
@@ -60,6 +61,30 @@ export async function deleteAlias(e: EventType) {
   }
   settings.removeArrayleConfig('alias', oriName, key)
   await e.reply(`角色 ${key} 别名删除成功`, false, {
+    at: true,
+    recallMsg: 100
+  })
+}
+
+export async function listAlias(e: EventType) {
+  // @ts-expect-error
+  e ||= this.e
+  const msg = e.msg.replace(new RegExp(rulePrefix), '').trim()
+  const match = /^(\S+)别名$/.exec(msg)
+  if (!match) return false
+  const [, key] = match
+  const oriName = char.aliasToName(key)
+  // 指令较为宽泛，未匹配到角色时交还给后续插件处理，避免误吞消息
+  if (!oriName) return false
+  const alias = settings.getConfig('alias')
+  const list = alias[oriName] || []
+  if (!list.length) {
+    return e.reply(`角色 ${oriName} 暂无别名，可发送“添加${oriName}别名xxx”添加`, false, {
+      at: true,
+      recallMsg: 100
+    })
+  }
+  return e.reply(`角色 ${oriName} 共 ${list.length} 个别名：\n${list.join('、')}`, false, {
     at: true,
     recallMsg: 100
   })


### PR DESCRIPTION
## 背景

插件已有「添加别名 / 删除别名」，但没有查看入口。主人加过别名之后无法确认某个角色当前到底有哪些别名，容易重复添加（撞上「别名 xxx 已存在」），也记不住自己加过什么。

## 实现

新增 `%角色名别名`，例如 `%南宫羽别名`、`%小羽别名`。

- `src/apps/manage/alias.ts` 新增 `listAlias`：去掉指令前缀后匹配 `^(\S+)别名$`，
  用既有的 `char.aliasToName` 反查角色，再从 `settings.getConfig('alias')`
  取实际生效的别名列表回复。取数与 `aliasToName` 同源，添加后立即可见。
- `src/apps/manage.ts` 注册规则，位置放在 `addAlias`、`deleteAlias` 之后。
- `src/apps/help.ts` 补充帮助条目。

角色本名、全名、任意一个已有别名都能查。指令正则较为宽泛，未匹配到角色时
返回 `false` 交还给后续插件处理，避免误吞其他插件以「别名」结尾的指令。

只改了 3 个文件、纯新增 38 行，没有触碰 `addAlias` / `deleteAlias` 的任何逻辑。

## 验证

`npx tsc --noEmit` 与 `npx eslint "src/**/*.ts" "src/**/*.js"` 均通过（0 报错）。

用真实的 `config/alias.yaml` 与 `PartnerId2Data.json` 跑过下列用例：

```
[%南宫羽别名]         角色本名
-> 角色 南宫羽 共 6 个别名：
   节拍精灵南宫羽、独到舞步南宫羽、燃炸全场南宫羽、南宫、小羽、危险爆炸小姐

[%小羽别名]           已有别名反查   -> 同上
[%危险爆炸小姐别名]   手动加的别名反查 -> 同上
[%安比·德玛拉别名]    full_name 反查
-> 角色 安比 共 2 个别名：安比、安笔

[%希格莉德别名]       alias.yaml 中无条目的角色
-> 角色 希格莉德 暂无别名，可发送“添加希格莉德别名xxx”添加

[%阿罗夏别名]         不存在的角色   -> return false
[%添加别名]           残缺指令       -> return false
[%别名]               只有“别名”     -> return false
```

规则命中顺序（Yunzai 按 `rule` 数组顺序匹配，命中即执行，返回 `false` 才继续）：

```
[%添加南宫羽别名危险爆炸小姐] -> addAlias
[%删除别名危险爆炸小姐]       -> deleteAlias
[%南宫羽别名]                 -> listAlias
[%添加别名]                   -> listAlias（角色查不到，返回 false 继续后续插件）
```

## 顺带发现的既有问题（本 PR 未处理）

`settings.getConfig` 对 `alias` 是 `{ ...defSet, ...config }` 的浅合并，
某个角色一旦被写进 `config/alias.yaml`，该角色整键覆盖 `defSet` 的值。
所以插件更新时给老角色新增的默认别名，在已经跑过一段时间的实例上不会生效。
以「南宫羽」为例，`defSet` 里的「南官」「南工」在本地实例上查不到。
这属于配置合并策略问题，和本 PR 的查看功能是两件事，就没在这里一起改。
需要的话我可以另开 PR 处理。
