### PR TITLE
feat: 提示消息撤回时间改为可配置，0 为不撤回

### DIFF
--- a/defSet/config.yaml
+++ b/defSet/config.yaml
@@ -1,5 +1,7 @@
 render:
   scale: 100 # 渲染精度
+# 提示类消息自动撤回时间（秒），取值0~120，0为不撤回
+recallMsg: 100
 query:
   others: true # 允许查询他人信息
 update:

--- a/guoba.support.js
+++ b/guoba.support.js
@@ -46,6 +46,19 @@ export function supportGuoba() {
           },
         },
         {
+          field: 'config.recallMsg',
+          label: '消息撤回时间',
+          bottomHelpMessage:
+            '设置提示类消息（权限提示、参数错误、设置成功等）的自动撤回时间，单位为秒，可选值0~120，0为不自动撤回',
+          component: 'InputNumber',
+          required: true,
+          componentProps: {
+            min: 0,
+            max: 120,
+            placeholder: '请输入数字，0为不撤回',
+          },
+        },
+        {
           field: 'config.url',
           label: '绑定设备下载url',
           bottomHelpMessage: '设置自定义的绑定绑定设备下载url',

--- a/src/@types/interface.d.ts
+++ b/src/@types/interface.d.ts
@@ -31,6 +31,8 @@ export namespace Config {
       /** 渲染精度 */
       scale: number
     }
+    /** 提示类消息自动撤回时间（秒），取值0~120，0为不撤回 */
+    recallMsg: number
     query: {
       /** 允许查询他人信息 */
     }

--- a/src/apps/gachalog.ts
+++ b/src/apps/gachalog.ts
@@ -4,7 +4,7 @@ import { gacha_type_meta_data, GachaType } from '../lib/gacha/const.js'
 import { getQueryVariable } from '../utils/network.js'
 import common from '../../../../lib/common/common.js'
 import { getAuthKey } from '../lib/authkey.js'
-import { rulePrefix } from '../lib/common.js'
+import { getRecallMsg, rulePrefix } from '../lib/common.js'
 import { ZZZPlugin } from '../lib/plugin.js'
 import settings from '../lib/settings.js'
 import _ from 'lodash'
@@ -65,7 +65,7 @@ export class GachaLog extends ZZZPlugin {
       if (!currentGroup) {
         return this.reply('获取群聊ID失败，请尝试私聊发送抽卡链接', false, {
           at: true,
-          recallMsg: 100
+          recallMsg: getRecallMsg()
         })
       }
       if (!allowGroup) {
@@ -75,7 +75,7 @@ export class GachaLog extends ZZZPlugin {
             false,
             {
               at: true,
-              recallMsg: 100
+              recallMsg: getRecallMsg()
             }
           )
         }
@@ -86,7 +86,7 @@ export class GachaLog extends ZZZPlugin {
             false,
             {
               at: true,
-              recallMsg: 100
+              recallMsg: getRecallMsg()
             }
           )
         }
@@ -94,14 +94,14 @@ export class GachaLog extends ZZZPlugin {
       await this.reply(
         '请注意，当前在群聊中发送抽卡链接，包含authkey，其他人获取authkey可能导致未知后果，请谨慎操作，请在机器人回复你获取链接成功后及时撤回抽卡链接消息。',
         false,
-        { at: true, recallMsg: 100 }
+        { at: true, recallMsg: getRecallMsg() }
       )
     }
     this.setContext('gachaLog')
     await this.reply(
       '请发送抽卡链接，发送“取消”即可取消本次抽卡链接刷新',
       false,
-      { at: true, recallMsg: 100 }
+      { at: true, recallMsg: getRecallMsg() }
     )
   }
 
@@ -109,7 +109,7 @@ export class GachaLog extends ZZZPlugin {
     const msg = this.e.msg.trim()
     if (msg.includes('取消')) {
       this.finish('gachaLog')
-      return this.reply('已取消', false, { at: true, recallMsg: 100 })
+      return this.reply('已取消', false, { at: true, recallMsg: getRecallMsg() })
     }
     const key = getQueryVariable(msg, 'authkey')
     const region = getQueryVariable(msg, 'region')
@@ -118,7 +118,7 @@ export class GachaLog extends ZZZPlugin {
       this.finish('gachaLog')
       return this.reply('抽卡链接格式错误，请重新发起%抽卡链接', false, {
         at: true,
-        recallMsg: 100
+        recallMsg: getRecallMsg()
       })
     }
     this.finish('gachaLog')
@@ -168,7 +168,7 @@ export class GachaLog extends ZZZPlugin {
     await this.reply(
       '抽卡链接解析成功，正在查询抽卡记录，可能耗费一段时间，请勿重复发送',
       false,
-      { at: true, recallMsg: 100 }
+      { at: true, recallMsg: getRecallMsg() }
     )
     let uid: string | undefined
     queryLabel: for (const name in gacha_type_meta_data) {
@@ -191,7 +191,7 @@ export class GachaLog extends ZZZPlugin {
     if (!uid) {
       return this.reply('未查询到uid，请检查链接是否正确', false, {
         at: true,
-        recallMsg: 100
+        recallMsg: getRecallMsg()
       })
     }
     const { data, count } = await updateGachaLog(key, uid, region, game_biz)
@@ -213,7 +213,7 @@ export class GachaLog extends ZZZPlugin {
     await this.getPlayerInfo()
     await this.reply('正在分析抽卡记录，请稍等', false, {
       at: true,
-      recallMsg: 100
+      recallMsg: getRecallMsg()
     })
     const data = await anaylizeGachaLog(uid)
     if (!data) {
@@ -222,7 +222,7 @@ export class GachaLog extends ZZZPlugin {
         false,
         {
           at: true,
-          recallMsg: 100
+          recallMsg: getRecallMsg()
         }
       )
     }

--- a/src/apps/help.ts
+++ b/src/apps/help.ts
@@ -596,6 +596,13 @@ export class Help extends ZZZPlugin {
               commands: ['设置渲染精度+50~200'],
             },
             {
+              title: '设置撤回时间',
+              desc: '设置提示类消息的自动撤回时间，单位为秒，取值范围为0~120，0为不撤回',
+              needCK: false,
+              needSK: false,
+              commands: ['设置撤回时间+0~120'],
+            },
+            {
               title: '刷新抽卡间隔',
               desc: '设置刷新抽卡记录的冷却时间，单位为秒，取值范围为0～1000',
               needCK: false,

--- a/src/apps/manage.ts
+++ b/src/apps/manage.ts
@@ -10,6 +10,7 @@ export class Manage extends ZZZPlugin {
   setDefaultGuide: typeof manage.guides.setDefaultGuide
   setMaxForwardGuide: typeof manage.guides.setMaxForwardGuide
   setRenderPrecision: typeof manage.config.setRenderPrecision
+  setRecallMsg: typeof manage.config.setRecallMsg
   setRefreshGachaInterval: typeof manage.config.setRefreshGachaInterval
   setRefreshPanelInterval: typeof manage.config.setRefreshPanelInterval
   setRefreshCharInterval: typeof manage.config.setRefreshCharInterval
@@ -54,6 +55,10 @@ export class Manage extends ZZZPlugin {
         {
           reg: `${rulePrefix}设置渲染精度(\\d+)$`,
           fnc: 'setRenderPrecision'
+        },
+        {
+          reg: `${rulePrefix}设置撤回时间(\\d+)$`,
+          fnc: 'setRecallMsg'
         },
         {
           reg: `${rulePrefix}刷新抽卡间隔(\\d+)$`,
@@ -127,6 +132,7 @@ export class Manage extends ZZZPlugin {
     this.setDefaultGuide = manage.guides.setDefaultGuide
     this.setMaxForwardGuide = manage.guides.setMaxForwardGuide
     this.setRenderPrecision = manage.config.setRenderPrecision
+    this.setRecallMsg = manage.config.setRecallMsg
     this.setRefreshGachaInterval = manage.config.setRefreshGachaInterval
     this.setRefreshPanelInterval = manage.config.setRefreshPanelInterval
     this.setRefreshCharInterval = manage.config.setRefreshCharInterval

--- a/src/apps/manage/alias.ts
+++ b/src/apps/manage/alias.ts
@@ -1,12 +1,13 @@
 import type { EventType } from '#interface'
 import { char } from '../../lib/convert.js'
+import { getRecallMsg } from '../../lib/common.js'
 import settings from '../../lib/settings.js'
 
 export async function addAlias(e: EventType) {
   // @ts-expect-error
   e ||= this.e
   if (!e.isMaster) {
-    return e.reply('仅限主人设置', false, { at: true, recallMsg: 100 })
+    return e.reply('仅限主人设置', false, { at: true, recallMsg: getRecallMsg() })
   }
   const match = /添加(\S+)别名(\S+)$/.exec(e.msg)
   if (!match) return false
@@ -16,21 +17,21 @@ export async function addAlias(e: EventType) {
   if (!oriName) {
     await e.reply(`未找到 ${value} 的对应角色`, false, {
       at: true,
-      recallMsg: 100
+      recallMsg: getRecallMsg()
     })
     return
   }
   if (isExist) {
     await e.reply(`别名 ${value} 已存在`, false, {
       at: true,
-      recallMsg: 100
+      recallMsg: getRecallMsg()
     })
     return
   }
   settings.addArrayleConfig('alias', oriName, value)
   await e.reply(`角色 ${key} 别名 ${value} 成功`, false, {
     at: true,
-    recallMsg: 100
+    recallMsg: getRecallMsg()
   })
 }
 
@@ -38,7 +39,7 @@ export async function deleteAlias(e: EventType) {
   // @ts-expect-error
   e ||= this.e
   if (!e.isMaster) {
-    return e.reply('仅限主人设置', false, { at: true, recallMsg: 100 })
+    return e.reply('仅限主人设置', false, { at: true, recallMsg: getRecallMsg() })
   }
   const match = /删除别名(\S+)$/.exec(e.msg)
   if (!match) return false
@@ -47,20 +48,20 @@ export async function deleteAlias(e: EventType) {
   if (!oriName) {
     await e.reply(`未找到 ${key} 的对应角色`, false, {
       at: true,
-      recallMsg: 100
+      recallMsg: getRecallMsg()
     })
     return
   }
   if (key === oriName) {
     await e.reply(`别名 ${key} 为角色本名，无法删除`, false, {
       at: true,
-      recallMsg: 100
+      recallMsg: getRecallMsg()
     })
     return
   }
   settings.removeArrayleConfig('alias', oriName, key)
   await e.reply(`角色 ${key} 别名删除成功`, false, {
     at: true,
-    recallMsg: 100
+    recallMsg: getRecallMsg()
   })
 }

--- a/src/apps/manage/assets.ts
+++ b/src/apps/manage/assets.ts
@@ -15,6 +15,7 @@ import { getAllSuitID } from '../../lib/convert/equip.js'
 import { getAllWeaponID } from '../../lib/convert/weapon.js'
 import { getAllBangbooID } from '../../lib/convert/bangboo.js'
 import * as LocalURI from '../../lib/download/const.js'
+import { getRecallMsg } from '../../lib/common.js'
 
 interface DownloadCounter {
   success: number
@@ -43,7 +44,7 @@ export async function downloadAll(e: EventType) {
   e ||= this.e
   if (!e.isMaster) return false
   if (downloading) {
-    return e.reply('下载任务正在进行中，请稍后再试', false, { at: true, recallMsg: 100 })
+    return e.reply('下载任务正在进行中，请稍后再试', false, { at: true, recallMsg: getRecallMsg() })
   }
   const charIDs = char.getAllCharactersID()
   const equipSprites = getAllSuitID()
@@ -99,7 +100,7 @@ export async function downloadAll(e: EventType) {
   await e.reply(
     '开始下载全部资源：代理人、音擎、驱动盘、邦布图片等，请耐心等待……',
     false,
-    { at: true, recallMsg: 100 }
+    { at: true, recallMsg: getRecallMsg() }
   )
   const downloadFnc = async (
     fnc: (id: number | string) => Promise<boolean | unknown>,
@@ -158,7 +159,7 @@ export async function deleteAll(e: EventType) {
   await e.reply(
     '【注意】正在删除所有资源图片，后续使用需要重新下载！',
     false,
-    { at: true, recallMsg: 100 }
+    { at: true, recallMsg: getRecallMsg() }
   )
   // 将 localURI 值迭代删除
   for (const dir of Object.values(LocalURI) as string[]) {
@@ -167,5 +168,5 @@ export async function deleteAll(e: EventType) {
       fs.rmSync(dir, { recursive: true, force: true })
     }
   }
-  await e.reply('资源图片已删除！', false, { at: true, recallMsg: 100 })
+  await e.reply('资源图片已删除！', false, { at: true, recallMsg: getRecallMsg() })
 }

--- a/src/apps/manage/config.ts
+++ b/src/apps/manage/config.ts
@@ -1,4 +1,5 @@
 import type { EventType } from '#interface'
+import { getRecallMsg, MAX_RECALL_MSG } from '../../lib/common.js'
 import settings from '../../lib/settings.js'
 
 /** 设置渲染精度 */
@@ -6,7 +7,7 @@ export async function setRenderPrecision(e: EventType) {
   // @ts-expect-error
   e ||= this.e
   if (!e.isMaster) {
-    return e.reply('仅限主人设置', false, { at: true, recallMsg: 100 })
+    return e.reply('仅限主人设置', false, { at: true, recallMsg: getRecallMsg() })
   }
   const match = /渲染精度(\d+)$/.exec(e.msg)
   if (!match) return false
@@ -14,13 +15,13 @@ export async function setRenderPrecision(e: EventType) {
   if (render_precision < 50) {
     return e.reply('渲染精度不能小于50', false, {
       at: true,
-      recallMsg: 100
+      recallMsg: getRecallMsg()
     })
   }
   if (render_precision > 200) {
     return e.reply('渲染精度不能大于200', false, {
       at: true,
-      recallMsg: 100
+      recallMsg: getRecallMsg()
     })
   }
   settings.setSingleConfig('config', 'render', {
@@ -34,7 +35,7 @@ export async function setRefreshGachaInterval(e: EventType) {
   // @ts-expect-error
   e ||= this.e
   if (!e.isMaster) {
-    return e.reply('仅限主人设置', false, { at: true, recallMsg: 100 })
+    return e.reply('仅限主人设置', false, { at: true, recallMsg: getRecallMsg() })
   }
   const match = /刷新抽卡间隔(\d+)$/.exec(e.msg)
   if (!match) return false
@@ -42,13 +43,13 @@ export async function setRefreshGachaInterval(e: EventType) {
   if (refresh_gacha_interval < 0) {
     return e.reply('刷新抽卡间隔不能小于0秒', false, {
       at: true,
-      recallMsg: 100
+      recallMsg: getRecallMsg()
     })
   }
   if (refresh_gacha_interval > 1000) {
     return e.reply('刷新抽卡间隔不能大于1000秒', false, {
       at: true,
-      recallMsg: 100
+      recallMsg: getRecallMsg()
     })
   }
   settings.setSingleConfig('gacha', 'interval', refresh_gacha_interval)
@@ -60,7 +61,7 @@ export async function setRefreshPanelInterval(e: EventType) {
   // @ts-expect-error
   e ||= this.e
   if (!e.isMaster) {
-    return e.reply('仅限主人设置', false, { at: true, recallMsg: 100 })
+    return e.reply('仅限主人设置', false, { at: true, recallMsg: getRecallMsg() })
   }
   const match = /刷新面板间隔(\d+)$/.exec(e.msg)
   if (!match) return false
@@ -68,20 +69,20 @@ export async function setRefreshPanelInterval(e: EventType) {
   if (refresh_panel_interval < 0) {
     return e.reply('刷新面板间隔不能小于0秒', false, {
       at: true,
-      recallMsg: 100
+      recallMsg: getRecallMsg()
     })
   }
   if (refresh_panel_interval > 1000) {
     return e.reply('刷新面板间隔不能大于1000秒', false, {
       at: true,
-      recallMsg: 100
+      recallMsg: getRecallMsg()
     })
   }
   settings.setSingleConfig('panel', 'interval', refresh_panel_interval)
   await e.reply(
     `绝区零刷新面板间隔已设置为: ${refresh_panel_interval}`,
     false,
-    { at: true, recallMsg: 100 }
+    { at: true, recallMsg: getRecallMsg() }
   )
 }
 
@@ -90,7 +91,7 @@ export async function setRefreshCharInterval(e: EventType) {
   // @ts-expect-error
   e ||= this.e
   if (!e.isMaster) {
-    return e.reply('仅限主人设置', false, { at: true, recallMsg: 100 })
+    return e.reply('仅限主人设置', false, { at: true, recallMsg: getRecallMsg() })
   }
   const match = /刷新角色间隔(\d+)$/.exec(e.msg)
   if (!match) return false
@@ -98,15 +99,39 @@ export async function setRefreshCharInterval(e: EventType) {
   if (refresh_char_interval < 100) {
     return e.reply('刷新角色间隔不能小于100毫秒', false, {
       at: true,
-      recallMsg: 100
+      recallMsg: getRecallMsg()
     })
   }
   if (refresh_char_interval > 10000) {
     return e.reply('刷新角色间隔不能大于10000毫秒', false, {
       at: true,
-      recallMsg: 100
+      recallMsg: getRecallMsg()
     })
   }
   settings.setSingleConfig('panel', 'roleInterval', refresh_char_interval)
   await e.reply(`绝区零刷新角色间隔已设置为: ${refresh_char_interval}毫秒`)
+}
+
+/** 设置提示类消息的自动撤回时间 */
+export async function setRecallMsg(e: EventType) {
+  // @ts-expect-error
+  e ||= this.e
+  if (!e.isMaster) {
+    return e.reply('仅限主人设置', false, { at: true, recallMsg: getRecallMsg() })
+  }
+  const match = /撤回时间(\d+)$/.exec(e.msg)
+  if (!match) return false
+  const recall_msg = Number(match[1])
+  if (recall_msg > MAX_RECALL_MSG) {
+    return e.reply(`撤回时间不能大于${MAX_RECALL_MSG}秒`, false, {
+      at: true,
+      recallMsg: getRecallMsg()
+    })
+  }
+  settings.setSingleConfig('config', 'recallMsg', recall_msg)
+  await e.reply(
+    recall_msg > 0
+      ? `绝区零提示消息撤回时间已设置为: ${recall_msg}秒`
+      : '绝区零提示消息已设置为不自动撤回'
+  )
 }

--- a/src/apps/manage/device.ts
+++ b/src/apps/manage/device.ts
@@ -1,18 +1,19 @@
 import type { EventType } from '#interface'
+import { getRecallMsg } from '../../lib/common.js'
 import settings from '../../lib/settings.js'
 
 export async function setDefaultDevice(e: EventType) {
   // @ts-expect-error
   e ||= this.e
   if (!e.isMaster) {
-    return e.reply('仅限主人设置', false, { at: true, recallMsg: 100 })
+    return e.reply('仅限主人设置', false, { at: true, recallMsg: getRecallMsg() })
   }
   // @ts-expect-error
   this.setContext('toSetDefaultDevice')
   await e.reply(
     '请发送默认设备信息，或者发送“取消”取消设置默认设备信息',
     false,
-    { at: true, recallMsg: 100 }
+    { at: true, recallMsg: getRecallMsg() }
   )
 }
 
@@ -21,17 +22,17 @@ export async function toSetDefaultDevice(e: EventType) {
   e = this.e
   const msg = e.msg.trim()
   if (!msg) {
-    return e.reply('请发送设备信息', false, { at: true, recallMsg: 100 })
+    return e.reply('请发送设备信息', false, { at: true, recallMsg: getRecallMsg() })
   }
   if (msg.includes('取消')) {
     // @ts-expect-error
     this.finish('toSetDefaultDevice')
-    return e.reply('已取消', false, { at: true, recallMsg: 100 })
+    return e.reply('已取消', false, { at: true, recallMsg: getRecallMsg() })
   }
   try {
     const info = JSON.parse(msg) as Record<string, any>
     if (!info) {
-      return e.reply('设备信息格式错误', false, { at: true, recallMsg: 100 })
+      return e.reply('设备信息格式错误', false, { at: true, recallMsg: getRecallMsg() })
     }
     if (
       !info?.deviceName ||
@@ -41,7 +42,7 @@ export async function toSetDefaultDevice(e: EventType) {
       !info?.deviceFingerprint ||
       !info?.deviceProduct
     ) {
-      return e.reply('设备信息格式错误', false, { at: true, recallMsg: 100 })
+      return e.reply('设备信息格式错误', false, { at: true, recallMsg: getRecallMsg() })
     }
     settings.setConfig('device', {
       productName: info.deviceProduct,
@@ -51,9 +52,9 @@ export async function toSetDefaultDevice(e: EventType) {
       deviceInfo: info.deviceFingerprint,
       board: info.deviceBoard
     })
-    e.reply('默认设备信息设置成功', false, { at: true, recallMsg: 100 })
+    e.reply('默认设备信息设置成功', false, { at: true, recallMsg: getRecallMsg() })
   } catch (error) {
-    e.reply('设备信息格式错误', false, { at: true, recallMsg: 100 })
+    e.reply('设备信息格式错误', false, { at: true, recallMsg: getRecallMsg() })
   } finally {
     // @ts-expect-error
     this.finish('toSetDefaultDevice')

--- a/src/apps/manage/guides.ts
+++ b/src/apps/manage/guides.ts
@@ -1,5 +1,6 @@
 import type { EventType } from '#interface'
 import guides from '../../lib/guides.js'
+import { getRecallMsg } from '../../lib/common.js'
 import settings from '../../lib/settings.js'
 
 /** 设置默认攻略 */
@@ -7,7 +8,7 @@ export async function setDefaultGuide(e: EventType) {
   // @ts-expect-error
   e ||= this.e
   if (!e.isMaster) {
-    return e.reply('仅限主人设置', false, { at: true, recallMsg: 100 })
+    return e.reply('仅限主人设置', false, { at: true, recallMsg: getRecallMsg() })
   }
   const match = /设置默认攻略(\d+|all)$/.exec(e.msg)
   if (!match) return false
@@ -31,7 +32,7 @@ export async function setDefaultGuide(e: EventType) {
   await e.reply(
     `绝区零默认攻略已设置为: ${guide_id} (${source_name})`,
     false,
-    { at: true, recallMsg: 100 }
+    { at: true, recallMsg: getRecallMsg() }
   )
 }
 
@@ -40,7 +41,7 @@ export async function setMaxForwardGuide(e: EventType) {
   // @ts-expect-error
   e ||= this.e
   if (!e.isMaster) {
-    return e.reply('仅限主人设置', false, { at: true, recallMsg: 100 })
+    return e.reply('仅限主人设置', false, { at: true, recallMsg: getRecallMsg() })
   }
   const match = /设置所有攻略显示个数(\d+)$/.exec(e.msg)
   if (!match) return false
@@ -48,19 +49,19 @@ export async function setMaxForwardGuide(e: EventType) {
   if (max_forward_guide < 1) {
     return e.reply('所有攻略显示个数不能小于1', false, {
       at: true,
-      recallMsg: 100
+      recallMsg: getRecallMsg()
     })
   }
   if (max_forward_guide > guides.guideMaxNum) {
     return e.reply(`所有攻略显示个数不能大于${guides.guideMaxNum}`, false, {
       at: true,
-      recallMsg: 100
+      recallMsg: getRecallMsg()
     })
   }
   settings.setSingleConfig('guide', 'max_forward_guides', max_forward_guide)
   await e.reply(
     `绝区零所有攻略显示个数已设置为: ${max_forward_guide}`,
     false,
-    { at: true, recallMsg: 100 }
+    { at: true, recallMsg: getRecallMsg() }
   )
 }

--- a/src/apps/manage/panel.ts
+++ b/src/apps/manage/panel.ts
@@ -3,6 +3,7 @@ import type { MessageElem } from 'icqq'
 import { char } from '../../lib/convert.js'
 import { downloadFile } from '../../lib/download/core.js'
 import { imageResourcesPath } from '../../lib/path.js'
+import { getRecallMsg } from '../../lib/common.js'
 import common from '../../../../../lib/common/common.js'
 import fs from 'fs'
 import path from 'path'
@@ -11,7 +12,7 @@ export async function uploadCharacterImg(e: EventType) {
   // @ts-expect-error
   e ||= this.e
   if (!e.isMaster) {
-    return e.reply('只有主人才能添加', false, { at: true, recallMsg: 100 })
+    return e.reply('只有主人才能添加', false, { at: true, recallMsg: getRecallMsg() })
   }
   const reg = /(上传|添加)(.+)(角色|面板)图$/
   const match = e.msg.match(reg)
@@ -21,7 +22,7 @@ export async function uploadCharacterImg(e: EventType) {
   const charName = match[2].trim()
   const name = char.aliasToName(charName)
   if (!name) {
-    return e.reply('未找到对应角色', false, { at: true, recallMsg: 100 })
+    return e.reply('未找到对应角色', false, { at: true, recallMsg: getRecallMsg() })
   }
   const images: MessageElem[] = []
   // 下面方法来源于miao-plugin/apps/character/ImgUpload.js
@@ -75,7 +76,7 @@ export async function uploadCharacterImg(e: EventType) {
     return e.reply(
       '消息中未找到图片，请将要发送的图片与消息一同发送或引用要添加的图像。',
       false,
-      { at: true, recallMsg: 100 }
+      { at: true, recallMsg: getRecallMsg() }
     )
   }
   const resourcesImagesPath = imageResourcesPath
@@ -99,7 +100,7 @@ export async function uploadCharacterImg(e: EventType) {
   }
   return e.reply(`成功上传${success}张图片，失败${failed}张图片。`, false, {
     at: true,
-    recallMsg: 100
+    recallMsg: getRecallMsg()
   })
 }
 
@@ -115,7 +116,7 @@ export async function getCharacterImages(e: EventType) {
   const name = char.aliasToName(charName)
   let page: number | string | undefined = match[4]
   if (!name) {
-    return e.reply('未找到对应角色', false, { at: true, recallMsg: 100 })
+    return e.reply('未找到对应角色', false, { at: true, recallMsg: getRecallMsg() })
   }
   const pageSize = 5
   const resourcesImagesPath = imageResourcesPath
@@ -132,7 +133,7 @@ export async function getCharacterImages(e: EventType) {
   const start = (page - 1) * pageSize
   const end = page * pageSize
   if (start >= images.length) {
-    return e.reply('哪有这么多图片', false, { at: true, recallMsg: 100 })
+    return e.reply('哪有这么多图片', false, { at: true, recallMsg: getRecallMsg() })
   }
   const imagePaths = images.slice(start, end)
   const imageMsg: Array<string | (string | MessageElem)[]> = imagePaths.map(imagePath => {
@@ -156,7 +157,7 @@ export async function deleteCharacterImg(e: EventType) {
   // @ts-expect-error
   e ||= this.e
   if (!e.isMaster) {
-    return e.reply('只有主人才能删除', false, { at: true, recallMsg: 100 })
+    return e.reply('只有主人才能删除', false, { at: true, recallMsg: getRecallMsg() })
   }
   const reg = /(删除)(.+)(角色|面板)图(.+)$/
   const match = e.msg.match(reg)
@@ -166,7 +167,7 @@ export async function deleteCharacterImg(e: EventType) {
   const charName = match[2].trim()
   const name = char.aliasToName(charName)
   if (!name) {
-    return e.reply('未找到对应角色', false, { at: true, recallMsg: 100 })
+    return e.reply('未找到对应角色', false, { at: true, recallMsg: getRecallMsg() })
   }
   const ids = match[4].split(/[,，、\s]+/)
   const resourcesImagesPath = imageResourcesPath

--- a/src/apps/manage/rank.ts
+++ b/src/apps/manage/rank.ts
@@ -1,11 +1,12 @@
 import type { EventType } from '#interface'
 import { setGroupRankAllowed, removeGroupRank } from '../../lib/rank.js'
+import { getRecallMsg } from '../../lib/common.js'
 
 export async function switchGroupRank(e: EventType) {
   // @ts-expect-error
   e ||= this.e
   if (!e.isMaster) {
-    return e.reply('仅限主人设置', false, { at: true, recallMsg: 100 })
+    return e.reply('仅限主人设置', false, { at: true, recallMsg: getRecallMsg() })
   }
   // 使用正则判断是否包含"开启"
   const enableRegex = /开启|打开|on|启用|启动/i
@@ -19,14 +20,14 @@ export async function switchGroupRank(e: EventType) {
   } else {
     // 如果都不匹配，默认使用开启/关闭的逻辑（根据是否有"开启"）
     // 或者返回错误提示
-    return e.reply('请输入"开启"或"关闭"来设置群内深渊排名功能', false, { at: true, recallMsg: 100 })
+    return e.reply('请输入"开启"或"关闭"来设置群内深渊排名功能', false, { at: true, recallMsg: getRecallMsg() })
   }
   setGroupRankAllowed(isEnable)
   const enableString = isEnable ? '开启' : '关闭'
   await e.reply(
     `绝区零群内深渊排名功能已设置为: ${enableString}`,
     false,
-    { at: true, recallMsg: 100 }
+    { at: true, recallMsg: getRecallMsg() }
   )
 }
 
@@ -56,8 +57,8 @@ export async function resetGroupRank(e: EventType) {
     for (const rank_type of rank_types) {
       await removeGroupRank(rank_type, e.group_id)
     }
-    return e.reply(`清除${rank_type_str}排名成功！`, false, { at: true, recallMsg: 100 })
+    return e.reply(`清除${rank_type_str}排名成功！`, false, { at: true, recallMsg: getRecallMsg() })
   } else {
-    return e.reply('仅限主人操作', false, { at: true, recallMsg: 100 })
+    return e.reply('仅限主人操作', false, { at: true, recallMsg: getRecallMsg() })
   }
 }

--- a/src/apps/manage/version.ts
+++ b/src/apps/manage/version.ts
@@ -2,6 +2,7 @@ import type { EventType } from '#interface'
 import version from '../../lib/version.js'
 import { ZZZUpdate } from '../../lib/update.js'
 import { pluginName } from '../../lib/path.js'
+import { getRecallMsg } from '../../lib/common.js'
 import settings from '../../lib/settings.js'
 
 export async function getChangeLog(e: EventType) {
@@ -30,7 +31,7 @@ export async function getCommitLog(e: EventType) {
     } catch (error: any) {
       e.reply(`[${pluginName}]获取更新日志失败\n${error.message}`, false, {
         at: true,
-        recallMsg: 100
+        recallMsg: getRecallMsg()
       })
     }
   }
@@ -64,7 +65,7 @@ export async function enableAutoUpdatePush(e: EventType) {
   // @ts-expect-error
   e ||= this.e
   if (!e.isMaster) {
-    return e.reply('仅限主人设置', false, { at: true, recallMsg: 100 })
+    return e.reply('仅限主人设置', false, { at: true, recallMsg: getRecallMsg() })
   }
   let enable = true
   if (e.msg.includes('关闭')) {
@@ -74,7 +75,7 @@ export async function enableAutoUpdatePush(e: EventType) {
   await e.reply(
     `[${pluginName}]自动更新推送${enable ? '已开启' : '已关闭'}`,
     false,
-    { at: true, recallMsg: 100 }
+    { at: true, recallMsg: getRecallMsg() }
   )
 }
 
@@ -83,7 +84,7 @@ export async function setCheckUpdateCron(e: EventType) {
   // @ts-expect-error
   e ||= this.e
   if (!e.isMaster) {
-    return e.reply('仅限主人设置', false, { at: true, recallMsg: 100 })
+    return e.reply('仅限主人设置', false, { at: true, recallMsg: getRecallMsg() })
   }
   const cron = e.msg.split('时间')[1]
   if (!cron) {
@@ -92,13 +93,13 @@ export async function setCheckUpdateCron(e: EventType) {
       false,
       {
         at: true,
-        recallMsg: 100
+        recallMsg: getRecallMsg()
       }
     )
   }
   settings.setSingleConfig('config', 'update', { cron })
   await e.reply(`[${pluginName}]自动更新频率已设置为${cron}`, false, {
     at: true,
-    recallMsg: 100
+    recallMsg: getRecallMsg()
   })
 }

--- a/src/apps/remind.ts
+++ b/src/apps/remind.ts
@@ -1,5 +1,5 @@
 import type { MysZZZApi } from '#interface'
-import { rulePrefix } from '../lib/common.js'
+import { getRecallMsg, rulePrefix } from '../lib/common.js'
 import { ZZZPlugin } from '../lib/plugin.js'
 import settings from '../lib/settings.js'
 import _ from 'lodash'
@@ -181,7 +181,7 @@ export class Remind extends ZZZPlugin {
 
   async setGlobalRemindEnable() {
     if (!this.e.isMaster) {
-      return this.reply('仅限主人设置', false, { at: true, recallMsg: 100 })
+      return this.reply('仅限主人设置', false, { at: true, recallMsg: getRecallMsg() })
     }
     const enable = /(开启|启用)全局挑战提醒$/.test(this.e.msg)
     if (settings.getConfig('remind').enable === enable) {
@@ -194,7 +194,7 @@ export class Remind extends ZZZPlugin {
   async setAbyssThreshold() {
     const isGlobal = this.e.msg.includes('全局')
     if (isGlobal && !this.e.isMaster) {
-      return this.reply('仅限主人设置', false, { at: true, recallMsg: 100 })
+      return this.reply('仅限主人设置', false, { at: true, recallMsg: getRecallMsg() })
     }
     if (!isGlobal && !this.checkEnableAndFriend()) return
     const match = this.e.msg.match(/设置(?:全局)?(?:式舆防卫战|式舆|深渊|防卫战|防卫)阈值\s*(\d+)/)
@@ -227,7 +227,7 @@ export class Remind extends ZZZPlugin {
   async setDeadlyThreshold() {
     const isGlobal = this.e.msg.includes('全局')
     if (isGlobal && !this.e.isMaster) {
-      return this.reply('仅限主人设置', false, { at: true, recallMsg: 100 })
+      return this.reply('仅限主人设置', false, { at: true, recallMsg: getRecallMsg() })
     }
     if (!isGlobal && !this.checkEnableAndFriend()) return
     const match = this.e.msg.match(/设置(?:全局)?(?:危局强袭战|危局|强袭|强袭战)阈值\s*(\d+)/)
@@ -518,7 +518,7 @@ export class Remind extends ZZZPlugin {
 
   async setGlobalRemindTime() {
     if (!this.e.isMaster) {
-      return this.reply('仅限主人设置', false, { at: true, recallMsg: 100 })
+      return this.reply('仅限主人设置', false, { at: true, recallMsg: getRecallMsg() })
     }
 
     const { remindTime: globalRemindTime, error } = this.parseRemindTimeMessage(this.e.msg)

--- a/src/apps/user.ts
+++ b/src/apps/user.ts
@@ -1,5 +1,5 @@
 import common from '../../../../lib/common/common.js'
-import { rulePrefix } from '../lib/common.js'
+import { getRecallMsg, rulePrefix } from '../lib/common.js'
 import { ZZZPlugin } from '../lib/plugin.js'
 import settings from '../lib/settings.js'
 import _ from 'lodash'
@@ -52,7 +52,7 @@ export class User extends ZZZPlugin {
     await this.reply(
       `为UID ${uid}绑定设备，请发送设备信息(建议私聊发送)，或者发送“取消”取消绑定`,
       false,
-      { at: true, recallMsg: 100 }
+      { at: true, recallMsg: getRecallMsg() }
     )
   }
 
@@ -64,22 +64,22 @@ export class User extends ZZZPlugin {
     }
     const msg = this.e.msg.trim()
     if (!msg) {
-      return this.reply('请发送设备信息', false, { at: true, recallMsg: 100 })
+      return this.reply('请发送设备信息', false, { at: true, recallMsg: getRecallMsg() })
     }
     if (msg.includes('取消')) {
       this.finish('toBindDevice')
-      return this.reply('已取消', false, { at: true, recallMsg: 100 })
+      return this.reply('已取消', false, { at: true, recallMsg: getRecallMsg() })
     }
     try {
       const info = JSON.parse(msg) as DeviceBindInfo | DeviceInfo
       if (!info) {
-        return this.reply('设备信息格式错误', false, { at: true, recallMsg: 100 })
+        return this.reply('设备信息格式错误', false, { at: true, recallMsg: getRecallMsg() })
       }
       if ((info as DeviceBindInfo)?.device_id && (info as DeviceBindInfo).device_fp) {
         this.finish('toBindDevice')
         await redis.set(`ZZZ:DEVICE_FP:${ltuid}:FP`, (info as DeviceBindInfo).device_fp)
         await redis.set(`ZZZ:DEVICE_FP:${ltuid}:ID`, (info as DeviceBindInfo).device_id)
-        return this.reply('绑定设备成功', false, { at: true, recallMsg: 100 })
+        return this.reply('绑定设备成功', false, { at: true, recallMsg: getRecallMsg() })
       }
       const deviceInfo = info as DeviceInfo
       if (
@@ -91,7 +91,7 @@ export class User extends ZZZPlugin {
         !deviceInfo?.deviceFingerprint ||
         !deviceInfo?.deviceProduct
       ) {
-        return this.reply('设备信息格式错误', false, { at: true, recallMsg: 100 })
+        return this.reply('设备信息格式错误', false, { at: true, recallMsg: getRecallMsg() })
       }
       await redis.del(`ZZZ:DEVICE_FP:${ltuid}:FP`)
       await redis.set(`ZZZ:DEVICE_FP:${ltuid}:BIND`, JSON.stringify(deviceInfo))
@@ -100,9 +100,9 @@ export class User extends ZZZPlugin {
         return this.reply('绑定设备失败')
       }
       logger.debug(`[LTUID:${ltuid}]绑定设备成功，deviceFp:${deviceFp}`)
-      await this.reply(`绑定设备成功${this.e.isGroup ? '\n请撤回设备信息' : ''}`, false, { at: true, recallMsg: 100 })
+      await this.reply(`绑定设备成功${this.e.isGroup ? '\n请撤回设备信息' : ''}`, false, { at: true, recallMsg: getRecallMsg() })
     } catch (error) {
-      return this.reply('设备信息格式错误', false, { at: true, recallMsg: 100 })
+      return this.reply('设备信息格式错误', false, { at: true, recallMsg: getRecallMsg() })
     } finally {
       this.finish('toBindDevice')
     }
@@ -115,7 +115,7 @@ export class User extends ZZZPlugin {
     await redis.del(`ZZZ:DEVICE_FP:${ltuid}:FP`)
     await redis.del(`ZZZ:DEVICE_FP:${ltuid}:BIND`)
     await redis.del(`ZZZ:DEVICE_FP:${ltuid}:ID`)
-    await this.reply('解绑设备成功', false, { at: true, recallMsg: 100 })
+    await this.reply('解绑设备成功', false, { at: true, recallMsg: getRecallMsg() })
   }
 
   async bindDeviceHelp() {

--- a/src/lib/common.ts
+++ b/src/lib/common.ts
@@ -1,8 +1,31 @@
 // @ts-ignore
 import User from '../../../genshin/model/user.js'
 import { getStoken } from './authkey.js'
+import settings from './settings.js'
 
 export const rulePrefix = '^((#|%|/)?(zzz|ZZZ|绝区零))'
+
+/** 提示类消息默认撤回时间（秒） */
+export const DEFAULT_RECALL_MSG = 100
+/** Yunzai 支持的撤回时间上限（秒） */
+export const MAX_RECALL_MSG = 120
+
+/**
+ * 提示类消息的自动撤回时间（秒）
+ *
+ * 读取 config.yaml 的 recallMsg，取值 0~120，0 为不撤回；
+ * 配置缺失、留空或非法时回退到默认值
+ */
+export const getRecallMsg = (): number => {
+  const raw: unknown = settings.getConfig('config')?.recallMsg
+  // null、留空、布尔、数组等都按未配置处理，避免被 Number() 静默转成 0 而变成不撤回
+  const value =
+    typeof raw === 'number' || (typeof raw === 'string' && raw.trim() !== '')
+      ? Number(raw)
+      : NaN
+  if (!Number.isFinite(value) || value < 0) return DEFAULT_RECALL_MSG
+  return Math.min(MAX_RECALL_MSG, Math.floor(value))
+}
 
 export interface Cookie {
   ck: string


### PR DESCRIPTION
已 rebase 到最新 `dev`（`fb66219`），解决了与 `#186` 合并产生的冲突。

## 背景

插件的提示类消息（权限提示、参数错误、设置成功等）在 82 处硬编码了
`recallMsg: 100`，主人既不能调整时长，也没法关掉自动撤回。

## 实现

新增配置项 `recallMsg`，指令 `%设置撤回时间0~120`，`0` 为不撤回。

- `defSet/config.yaml` 新增 `recallMsg`，默认 `100`，保持原有行为
- `src/lib/common.ts` 新增 `getRecallMsg` 统一读取，同时导出
  `DEFAULT_RECALL_MSG` / `MAX_RECALL_MSG`
- 82 处 `recallMsg: 100` 改为 `recallMsg: getRecallMsg()`，涉及 11 个文件
- `#186` 合并后 `listAlias` 里遗留的两处硬编码也一并统一，否则主人设成
  「不撤回」后，别名查看的提示仍会在 100 秒后撤回
- `src/apps/manage/config.ts` 新增 `setRecallMsg`
- 同步补齐 `src/@types/interface.d.ts` 类型、`guoba.support.js` 锅巴项、
  `src/apps/help.ts` 帮助条目

取值处理：留空、`null`、非数字、负数都回退默认 `100`，超过 `120` 收敛到
`120`（Yunzai 的上限），小数向下取整。特意没有直接用 `Number(raw)`，
因为 `Number(null)` 和 `Number('')` 都是 `0`，会让「配置留空」被静默当成
「关闭撤回」。

## 兼容性

老实例的 `config/config.yaml` 里没有 `recallMsg` 键，`getConfig` 的
`{ ...defSet, ...config }` 浅合并会取到 `defSet` 的 `100`，升级后行为不变。

`recallMsg` 为 `0` 时 Yunzai 的 `loader.js` 本身就是
`if (recallMsg > 0 && res?.message_id)`，不会注册撤回定时器，所以不需要
额外分支。

## 验证

`npx tsc --noEmit` 与 `npx eslint "src/**/*.ts" "src/**/*.js"` 均通过（0 报错）。

在真实实例上跑了 15 组取值用例，全部通过：

```
真实配置（config.yaml 尚无 recallMsg 键）-> 100   老实例行为不变
100 -> 100      默认值
30  -> 30       自定义
0   -> 0        不撤回
120 -> 120      上限
999 -> 120      超上限收敛
-5  -> 100      负数回退
45.7 -> 45      小数向下取整
'30' -> 30      数字字符串
'abc' -> 100    非数字回退
null -> 100     yaml 写「recallMsg:」留空
''   -> 100     空串
'   ' -> 100    纯空格
true -> 100     布尔
[]   -> 100     数组
键缺失 -> 100
```

另外确认了写入语义：`setSingleConfig('config', 'recallMsg', 0)` 走
`{ ...defSet, ...config }` 浅合并，`enkaApi`、`mysCode`、`render.scale`
等其他键都保留。


