### PR TITLE
fix: 请求重试时重建 AbortController 并收窄 Accept-Encoding

### DIFF
--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -23,9 +23,7 @@ const _request = async (url: string, options: RequestInit) => {
  */
 const request = (url: string, options: RequestInit = {}, retry = 0, timeout = 15000) => {
   let err: any
-  const controller = new AbortController()
-  const { signal } = controller
-  const timeoutId = setTimeout(() => controller.abort(), timeout)
+
   options.headers = {
     'Content-Type': 'application/json',
     'User-Agent':
@@ -33,7 +31,7 @@ const request = (url: string, options: RequestInit = {}, retry = 0, timeout = 15
     'Accept-Language': 'zh-CN,zh;q=0.9,en;q=0.8',
     Accept:
       'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7',
-    'Accept-Encoding': 'gzip, deflate, br, zstd',
+    'Accept-Encoding': 'gzip, deflate',
     'Sec-Ch-Ua':
       '"Chromium";v="130", "Google Chrome";v="130", "Not?A_Brand";v="99"',
     'Sec-Ch-Ua-Mobile': '?0',
@@ -44,12 +42,18 @@ const request = (url: string, options: RequestInit = {}, retry = 0, timeout = 15
     'Sec-Fetch-User': '?1',
     ...(options?.headers || {}),
   }
+
   const _fetch = async (url: string, options: RequestInit, retryCount = 0) => {
     if (retryCount > retry) {
       throw new Error('Retry limit reached', err)
     }
+
+    // 每次重试创建独立的 AbortController 和超时定时器
+    const controller = new AbortController()
+    const timeoutId = setTimeout(() => controller.abort(), timeout)
+
     try {
-      return await _request(url, { signal, ...options })
+      return await _request(url, { signal: controller.signal, ...options })
     } catch (error: any) {
       logger.debug(
         `请求失败：` +


### PR DESCRIPTION
修改函数，解决因函数复用问题导致的JSON读取失败，获取版本信息异常

~~~
[  TRSSYz  ] 获取NanokaURL绝区零最新版本失败，使用原版本：3.1
[ERRO][  TRSSYz  ] Error: Retry limit reached
    at _fetch (file:///root/TRSS_AllBot/TRSS-Yunzai/plugins/ZZZ-Plugin/src/utils/request.ts:49:13)
    at _fetch (file:///root/TRSS_AllBot/TRSS-Yunzai/plugins/ZZZ-Plugin/src/utils/request.ts:61:20)
    at processTicksAndRejections (node:internal/process/task_queues:104:5)
    at _fetch (file:///root/TRSS_AllBot/TRSS-Yunzai/plugins/ZZZ-Plugin/src/utils/request.ts:61:14)
    at _fetch (file:///root/TRSS_AllBot/TRSS-Yunzai/plugins/ZZZ-Plugin/src/utils/request.ts:61:14)
    at _fetch (file:///root/TRSS_AllBot/TRSS-Yunzai/plugins/ZZZ-Plugin/src/utils/request.ts:61:14)
    at file:///root/TRSS_AllBot/TRSS-Yunzai/plugins/ZZZ-Plugin/src/lib/assets/nanokaurl.ts:19:26
~~~
已修复